### PR TITLE
Add Pi 400 Rev 1.1 (BCM2711) as a valid Pi

### DIFF
--- a/src/utility/get_pi_version.c
+++ b/src/utility/get_pi_version.c
@@ -238,6 +238,12 @@ static struct pi_version_struct pi_version[] = {
     {
         .revision_string = "c03115",
         .version = 4
+    },
+
+    // Pi 400 Rev 1.1
+    {
+        .revision_string = "c03131",
+        .version = 4
     }
 };
 


### PR DESCRIPTION
Hello @besp9510 , thanks for the great project 😄
This PR is just appending another revision of BCM2711 used for Raspberry Pi 400 Rev 1.1.